### PR TITLE
Fix: regexp in kernel cleanup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mx-cleanup (24.9.01) mx; urgency=medium
+
+  * Fix: regexp in kernel cleanup
+
+ -- fehlix <fehlix@mxlinux.org>  Sun, 15 Sep 2024 17:26:26 -0400
+
 mx-cleanup (24.4.01) mx; urgency=medium
 
   * Run cleanup script at reboot not immediately if option is selected

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -584,7 +584,8 @@ void MainWindow::pushKernel_clicked()
     QString other_kernels;
     if (system(R"(dpkg -l linux-image\* | grep ^ii)") == 0) {
         similar_kernels = cmdOut(R"(dpkg -l linux-image-[0-9]\*.[0-9]\* | grep ^ii |
-    grep $(uname -r | cut -f1 -d'-') | cut -f3 -d' ' | grep -v --extended-regexp linux-image-$(uname -r)'(-unsigned)?$')");
+    grep $(uname -r | cut -f1 -d'-') | cut -f3 -d' ' |
+    grep -vE -- '(-unsigned)?$' | grep -vF linux-image-$(uname -r))");
         other_kernels = cmdOut(R"(dpkg -l linux-image-[0-9]\*.[0-9]\* | grep ^ii |
     grep -v $(uname -r | cut -f1 -d'-') | cut -f3 -d' ')");
     }


### PR DESCRIPTION
this is to avoid regexp eats a +-sign with kernel version e.g. for +bpo kernels.