### PR TITLE
regexp in kernel cleanup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
 mx-cleanup (24.9.01) mx; urgency=medium
 
   * Fix: regexp in kernel cleanup
+  * Add: kernel removal list, sorted by version
+  * Fix: debconf frontend as non-gui to avoid error warnings
 
- -- fehlix <fehlix@mxlinux.org>  Sun, 15 Sep 2024 17:26:26 -0400
+ -- fehlix <fehlix@mxlinux.org>  Tue, 17 Sep 2024 15:09:20 -0400
 
 mx-cleanup (24.4.01) mx; urgency=medium
 

--- a/scripts/helper-terminal
+++ b/scripts/helper-terminal
@@ -1,2 +1,3 @@
 #!/bin/bash
+export DEBIAN_FRONTEND=dialog
 eval "${*}"


### PR DESCRIPTION
Fix: regexp in kernel cleanup
Add: kernel removal list, sorted by version
Fix: debconf frontend as non-gui to avoid error warnings
